### PR TITLE
feature/sprint-5-2539

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ public class ExampleController {
 
 * The `FrontController` class (located in `src/winter/controllers/FrontController.java`) intercepts incoming URLs, identifies the requested one, and displays it in the browser. It also provides details about the associated controller for that specific URL.
 * When the invoked method within a controller returns a `ModelView` object, the `FrontController` forwards the request to the corresponding JSP page.
+* `Error 500` is sent to the client when one of the following issues occurs:
+  * Package provider not found in the configuration file.
+  * Provided package name is invalid.
+  * Multiple methods have the same `@GetMapping` value.
+  * Mapped method return value is neither `String` nor `ModelView`.
+* `Error 404` is sent to the client when the requested URL doesn't match any `@GetMapping`.
 * The `@Controller` annotation is used to annotate all classes that are wanted to be scanned as a controller.
 * The `@GetMapping` annotation is used to map controller methods to specific URLs, allowing for handling GET requests.
 * The `Mapping` data structure stores information about a URL and its associated controller.

--- a/src/winter/controllers/FrontController.java
+++ b/src/winter/controllers/FrontController.java
@@ -91,7 +91,7 @@ public class FrontController extends HttpServlet {
             HtmlElementBuilder.printRequestInfo(out, req.getRequestURL().toString());
 
             try {
-                handleRequest(out, req, resp, targetURL);
+                handleRequest(req, resp, targetURL, out);
             } catch (MappingNotFoundException | InvalidReturnTypeException e) {
                 ExceptionHandler.handleException(e, Level.WARNING, resp);
             } catch (ReflectiveOperationException e) {
@@ -104,7 +104,7 @@ public class FrontController extends HttpServlet {
         }
     }
 
-    private void handleRequest(PrintWriter out, HttpServletRequest req, HttpServletResponse resp, String targetURL)
+    private void handleRequest(HttpServletRequest req, HttpServletResponse resp, String targetURL, PrintWriter out)
             throws MappingNotFoundException, ReflectiveOperationException, InvalidReturnTypeException, ServletException,
             IOException {
         Mapping mapping = urlMappings.get(targetURL);

--- a/src/winter/controllers/FrontController.java
+++ b/src/winter/controllers/FrontController.java
@@ -75,10 +75,11 @@ public class FrontController extends HttpServlet {
     }
 
     private void processRequest(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        handleInitExceptions(resp);
+
         String targetURL = UrlUtil.extractTargetURL(req);
-
         resp.setContentType("text/html");
-
+        
         try (PrintWriter out = resp.getWriter()) {
             HtmlElementBuilder.printRequestInfo(out, req.getRequestURL().toString());
 

--- a/src/winter/exceptions/DuplicateMappingException.java
+++ b/src/winter/exceptions/DuplicateMappingException.java
@@ -1,0 +1,11 @@
+package winter.exceptions;
+
+public class DuplicateMappingException extends RuntimeException {
+    public DuplicateMappingException(String msg) {
+        super(msg);
+    }
+
+    public DuplicateMappingException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/winter/exceptions/InvalidPackageNameException.java
+++ b/src/winter/exceptions/InvalidPackageNameException.java
@@ -1,0 +1,11 @@
+package winter.exceptions;
+
+public class InvalidPackageNameException extends Exception {
+    public InvalidPackageNameException(String msg) {
+        super(msg);
+    }
+
+    public InvalidPackageNameException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/winter/exceptions/PackageProviderNotFoundException.java
+++ b/src/winter/exceptions/PackageProviderNotFoundException.java
@@ -1,0 +1,11 @@
+package winter.exceptions;
+
+public class PackageProviderNotFoundException extends Exception {
+    public PackageProviderNotFoundException(String msg) {
+        super(msg);
+    }
+
+    public PackageProviderNotFoundException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -11,15 +11,22 @@ import java.util.Map;
 import jakarta.servlet.ServletContext;
 import winter.data.Mapping;
 import winter.exceptions.DuplicateMappingException;
+import winter.exceptions.InvalidPackageNameException;
+import winter.exceptions.PackageProviderNotFoundException;
 import winter.annotations.*;
 
 public class AnnotationScanner extends Utility {
     public static Map<String, Mapping> scanControllers(ServletContext servletContext, Map<String, Mapping> urlMappings)
-            throws URISyntaxException, IOException, ClassNotFoundException {
+            throws PackageProviderNotFoundException, InvalidPackageNameException, URISyntaxException, IOException,
+            ClassNotFoundException {
         String controllersPackage = servletContext.getInitParameter("ControllersPackage");
 
         if (controllersPackage == null) {
-            throw new PackageProviderNotFoundException();
+            throw new PackageProviderNotFoundException("No package provider was found in the configuration file");
+        }
+
+        if (!PackageNameValidator.isValidPackageName(controllersPackage)) {
+            throw new InvalidPackageNameException("Invalid provided package name in the configuration file");
         }
 
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -17,6 +17,11 @@ public class AnnotationScanner extends Utility {
     public static Map<String, Mapping> scanControllers(ServletContext servletContext, Map<String, Mapping> urlMappings)
             throws URISyntaxException, IOException, ClassNotFoundException {
         String controllersPackage = servletContext.getInitParameter("ControllersPackage");
+
+        if (controllersPackage == null) {
+            throw new PackageProviderNotFoundException();
+        }
+
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         Enumeration<URL> resources = classLoader.getResources(controllersPackage.replace(".", "/"));
 

--- a/src/winter/utils/ExceptionHandler.java
+++ b/src/winter/utils/ExceptionHandler.java
@@ -1,0 +1,35 @@
+package winter.utils;
+
+import jakarta.servlet.http.HttpServletResponse;
+import winter.exceptions.MappingNotFoundException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ExceptionHandler extends Utility {
+    private static final Logger logger = Logger.getLogger(ExceptionHandler.class.getName());
+
+    public static void handleException(Exception e, Level level, HttpServletResponse resp) {
+        logger.log(level, e.getMessage(), e);
+
+        try {
+            if (!resp.isCommitted()) {
+                if (e instanceof MappingNotFoundException) {
+                    resp.sendError(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
+                } else {
+                    resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+                }
+            }
+        } catch (IOException ioException) {
+            logger.log(Level.SEVERE, "Error sending error response to client", ioException);
+        }
+    }
+
+    public static void handleInitExceptions(HttpServletResponse resp, List<Exception> initExceptions) {
+        for (Exception e : initExceptions) {
+            handleException(e, Level.SEVERE, resp);
+        }
+    }
+}

--- a/src/winter/utils/PackageNameValidator.java
+++ b/src/winter/utils/PackageNameValidator.java
@@ -1,0 +1,15 @@
+package winter.utils;
+
+import java.util.regex.Pattern;
+
+public class PackageNameValidator extends Utility {
+    private static final String PACKAGE_NAME_REGEX = "^(\\w+)(\\.(\\w+))*$";
+    private static final Pattern PACKAGE_NAME_PATTERN = Pattern.compile(PACKAGE_NAME_REGEX);
+
+    public static boolean isValidPackageName(String packageName) {
+        if (packageName == null || packageName.isEmpty()) {
+            return false;
+        }
+        return PACKAGE_NAME_PATTERN.matcher(packageName).matches();
+    }
+}


### PR DESCRIPTION
- `Error 500` is sent to the client when one of the following issues occurs:
  - Package provider not found in the configuration file.
  - Provided package name is invalid.
  - Multiple methods have the same `@GetMapping` value.
  - Mapped method return value is neither `String` nor `ModelView`.
- `Error 404` is sent to the client when the request URL doesn't match any `@GetMapping`.