### PR TITLE
feature/sprint-8-2539

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,0 @@
-MIT License
-
-Copyright © 2024 Hasina JY
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add the following XML configuration to your web application's `web.xml` file:
         <param-value>com.controllers</param-value>
     </context-param>
 ```
-Every class that the developer wants to be scanned as controller should be annotated as `@Controller`
+Every class that the developer wants to be scanned as controller should be annotated as `@Controller`.
 ```java
 import winter.annotations.Controller;
 
@@ -58,7 +58,7 @@ public class ExampleController {
     // Code goes here ...
 }
 ```
-Every method that the developer wants to be mapped to a URL should be annotated as `@GetMapping("mapping")`
+Every method that the developer wants to be mapped to a URL should be annotated as `@GetMapping("mapping")`.
 ```java
 import winter.annotations.Controller;
 
@@ -73,6 +73,27 @@ public class ExampleController {
     @GetMapping("test-mapping")
     public void exampleMethod(@RequestParam(name = "name") String name, ...) {
         // Code goes here...
+    }
+}
+```
+To use the session object, an attribute of type `Session` has to be defined with its `setter method`.
+```java
+import winter.annotations.Controller;
+import winter.annotations.GetMapping;
+import winter.data.Session;
+
+@Controller
+public class ExampleController {
+    private Session mySession;
+
+    public void setMySession(Session session) {
+        this.mySession = session;
+    }
+
+    @GetMapping("/session-create")
+    public String createSession() {
+        this.getMySession().add("greetings", "Hello, World!");
+        return "Session 'greetings' was created.";
     }
 }
 ```
@@ -94,6 +115,7 @@ public class ExampleController {
 * The `ModelView` data structure holds information about the target JSP and any attributes (data) that need to be passed along to it for rendering.
 * The `@RequestParam(name = "value")` annotation is used to annotate parameters to be mapped to a form attribute.
 * If the parameter is an object, the form attribute value should match the pattern `objectName.attributeName` where objectName is the value of the `@RequestParam` annotation or the declared name of the parameter if no annotation is provided.
+* The `Session` data type allows the developer the use an abstraction of the `HttpSession`.
 
 **Future Work:**
 

--- a/src/winter/data/Session.java
+++ b/src/winter/data/Session.java
@@ -34,4 +34,8 @@ public class Session {
     public void update(String key, Object value) {
         add(key, value);
     }
+
+    public Object get(String key) {
+        return this.getHttpSession().getAttribute(key);
+    }
 }

--- a/src/winter/data/Session.java
+++ b/src/winter/data/Session.java
@@ -1,0 +1,23 @@
+package winter.data;
+
+import jakarta.servlet.http.HttpSession;
+
+public class Session {
+    private HttpSession httpSession;
+
+    /* ------------------------------ Constructors ------------------------------ */
+    public Session() {}
+
+    public Session(HttpSession httpSession) {
+        this.setHttpSession(httpSession);
+    }
+
+    /* --------------------------- Getters and setters -------------------------- */
+    public HttpSession getHttpSession() {
+        return httpSession;
+    }
+
+    public void setHttpSession(HttpSession httpSession) {
+        this.httpSession = httpSession;
+    }
+}

--- a/src/winter/data/Session.java
+++ b/src/winter/data/Session.java
@@ -30,4 +30,8 @@ public class Session {
     public void delete(String key) {
         this.getHttpSession().removeAttribute(key);
     }
+
+    public void update(String key, Object value) {
+        add(key, value);
+    }
 }

--- a/src/winter/data/Session.java
+++ b/src/winter/data/Session.java
@@ -6,7 +6,8 @@ public class Session {
     private HttpSession httpSession;
 
     /* ------------------------------ Constructors ------------------------------ */
-    public Session() {}
+    public Session() {
+    }
 
     public Session(HttpSession httpSession) {
         this.setHttpSession(httpSession);
@@ -19,5 +20,10 @@ public class Session {
 
     public void setHttpSession(HttpSession httpSession) {
         this.httpSession = httpSession;
+    }
+
+    /* ----------------------------- Bridge methods ----------------------------- */
+    public void add(String key, Object value) {
+        this.getHttpSession().setAttribute(key, value);
     }
 }

--- a/src/winter/data/Session.java
+++ b/src/winter/data/Session.java
@@ -26,4 +26,8 @@ public class Session {
     public void add(String key, Object value) {
         this.getHttpSession().setAttribute(key, value);
     }
+
+    public void delete(String key) {
+        this.getHttpSession().removeAttribute(key);
+    }
 }

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -63,7 +63,13 @@ public class AnnotationScanner extends Utility {
 
         if (clazz.isAnnotationPresent(Controller.class)) {
             processControllerMethods(clazz, urlMappings);
+            injectSession(clazz);
         }
+    }
+
+    private static void injectSession(Class<?> clazz) {
+        // Check if the class has a Session attribute
+        // if true: call setter and inject session
     }
 
     private static void processControllerMethods(Class<?> clazz, Map<String, Mapping> urlMappings)

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -1,7 +1,6 @@
 package winter.utils;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -10,7 +9,6 @@ import java.util.Enumeration;
 import java.util.Map;
 
 import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpSession;
 import winter.data.Mapping;
 import winter.exceptions.DuplicateMappingException;
 import winter.exceptions.InvalidPackageNameException;
@@ -66,18 +64,6 @@ public class AnnotationScanner extends Utility {
         if (clazz.isAnnotationPresent(Controller.class)) {
             processControllerMethods(clazz, urlMappings);
         }
-    }
-
-    public static String hasSession(Class<?> clazz) {
-        Field[] attributes = clazz.getDeclaredFields();
-
-        for (Field attribute : attributes) {
-            if (attribute.getType() == HttpSession.class) {
-                return attribute.getName();
-            }
-        }
-
-        return null;
     }
 
     private static void processControllerMethods(Class<?> clazz, Map<String, Mapping> urlMappings)

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -65,27 +65,7 @@ public class AnnotationScanner extends Utility {
 
         if (clazz.isAnnotationPresent(Controller.class)) {
             processControllerMethods(clazz, urlMappings);
-            injectSession(clazz);
         }
-    }
-
-    private static void injectSession(Class<?> clazz) {
-        String sessionName = hasSession(clazz);
-
-        if (sessionName != null) {
-            String setterName = ReflectionUtil.getSetterName(sessionName);
-
-            try {
-                Method setterMethod = clazz.getMethod(setterName, HttpSession.class);
-                setterMethod.invoke(clazz.getDeclaredConstructor().newInstance(), null);
-                // TODO: Is Session static or not
-                // TODO: Which is faster: init injection or invoke injection
-            } catch (Exception e) {
-                // TODO: Handle exception if the setter method is not found
-            }
-        }
-
-        // if true: call setter and inject session
     }
 
     public static String hasSession(Class<?> clazz) {
@@ -94,7 +74,6 @@ public class AnnotationScanner extends Utility {
         for (Field attribute : attributes) {
             if (attribute.getType() == HttpSession.class) {
                 return attribute.getName();
-                
             }
         }
 

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -1,6 +1,7 @@
 package winter.utils;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -9,6 +10,7 @@ import java.util.Enumeration;
 import java.util.Map;
 
 import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpSession;
 import winter.data.Mapping;
 import winter.exceptions.DuplicateMappingException;
 import winter.exceptions.InvalidPackageNameException;
@@ -70,6 +72,18 @@ public class AnnotationScanner extends Utility {
     private static void injectSession(Class<?> clazz) {
         // Check if the class has a Session attribute
         // if true: call setter and inject session
+    }
+
+    public static boolean hasSession(Class<?> clazz) {
+        Field[] attributes = clazz.getDeclaredFields();
+
+        for (Field attribute : attributes) {
+            if (attribute.getType() == HttpSession.class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void processControllerMethods(Class<?> clazz, Map<String, Mapping> urlMappings)

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -70,20 +70,35 @@ public class AnnotationScanner extends Utility {
     }
 
     private static void injectSession(Class<?> clazz) {
-        // Check if the class has a Session attribute
+        String sessionName = hasSession(clazz);
+
+        if (sessionName != null) {
+            String setterName = ReflectionUtil.getSetterName(sessionName);
+
+            try {
+                Method setterMethod = clazz.getMethod(setterName, HttpSession.class);
+                setterMethod.invoke(clazz.getDeclaredConstructor().newInstance(), null);
+                // TODO: Is Session static or not
+                // TODO: Which is faster: init injection or invoke injection
+            } catch (Exception e) {
+                // TODO: Handle exception if the setter method is not found
+            }
+        }
+
         // if true: call setter and inject session
     }
 
-    public static boolean hasSession(Class<?> clazz) {
+    public static String hasSession(Class<?> clazz) {
         Field[] attributes = clazz.getDeclaredFields();
 
         for (Field attribute : attributes) {
             if (attribute.getType() == HttpSession.class) {
-                return true;
+                return attribute.getName();
+                
             }
         }
 
-        return false;
+        return null;
     }
 
     private static void processControllerMethods(Class<?> clazz, Map<String, Mapping> urlMappings)

--- a/src/winter/utils/ReflectionUtil.java
+++ b/src/winter/utils/ReflectionUtil.java
@@ -103,7 +103,7 @@ public class ReflectionUtil extends Utility {
         }
     }
 
-    private static String getSetterName(String attrName) {
+    protected static String getSetterName(String attrName) {
         return "set" + Character.toUpperCase(attrName.charAt(0)) + attrName.substring(1);
     }
 

--- a/src/winter/utils/ReflectionUtil.java
+++ b/src/winter/utils/ReflectionUtil.java
@@ -25,7 +25,13 @@ public class ReflectionUtil extends Utility {
             Class<?> clazz = Class.forName(className);
             Method method = clazz.getDeclaredMethod(methodName, mapping.getMethodParamTypes());
             Object[] args = initializeMethodArguments(method.getParameters(), req);
-            return method.invoke(clazz.getDeclaredConstructor().newInstance(), args);
+
+            // Inject session if it's defined
+            Object instanceObject = clazz.getDeclaredConstructor().newInstance();
+            injectSession(instanceObject, req.getSession());
+
+            // Invoke the controller method
+            return method.invoke(instanceObject, args);
         } catch (ClassNotFoundException e) {
             String message = "Class not found: " + className;
             throw new ReflectiveOperationException(message, e);

--- a/src/winter/utils/ReflectionUtil.java
+++ b/src/winter/utils/ReflectionUtil.java
@@ -40,6 +40,21 @@ public class ReflectionUtil extends Utility {
         }
     }
 
+    private static void injectSession(Object object, HttpSession httpSession)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException,
+            IllegalArgumentException, SecurityException {
+        Class<?> clazz = object.getClass();
+        String attrName = hasSession(clazz);
+
+        if (attrName != null) {
+            Method sessionSetterMethod = clazz.getDeclaredMethod(getSetterName(attrName), Session.class);
+
+            // Creates the framework session abstraction object
+            Session winterSession = new Session(httpSession);
+            sessionSetterMethod.invoke(object, winterSession);
+        }
+    }
+
     private static String hasSession(Class<?> clazz) {
         Field[] attributes = clazz.getDeclaredFields();
 

--- a/src/winter/utils/ReflectionUtil.java
+++ b/src/winter/utils/ReflectionUtil.java
@@ -1,5 +1,7 @@
 package winter.utils;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -7,8 +9,10 @@ import java.util.Enumeration;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import winter.annotations.RequestParam;
 import winter.data.Mapping;
+import winter.data.Session;
 import winter.exceptions.AnnotationNotFoundException;
 
 public class ReflectionUtil extends Utility {
@@ -34,6 +38,18 @@ public class ReflectionUtil extends Utility {
             String message = "Error invoking method: " + methodName;
             throw new ReflectiveOperationException(message, e);
         }
+    }
+
+    private static String hasSession(Class<?> clazz) {
+        Field[] attributes = clazz.getDeclaredFields();
+
+        for (Field attribute : attributes) {
+            if (attribute.getType() == Session.class) {
+                return attribute.getName();
+            }
+        }
+
+        return null;
     }
 
     private static Object[] initializeMethodArguments(Parameter[] methodParams, HttpServletRequest req)


### PR DESCRIPTION
- Create `Session` data type for the abstraction of `HttpRequest`.
- Allows the use of session by defining a `Session` attribute in the controller class with its associated `setter method`.
- Inject `HttpSession` to the controller if `Session` is defined.