### PR TITLE
feature/sprint-10-2539

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ public class ExampleController {
     }
 }
 ```
+To make the method a REST API method, use the `@Rest` annotation on the method.
+```java
+import winter.annotations.Controller;
+
+@Controller
+public class ExampleController {
+    @Rest
+    @GetMapping("test-mapping")
+    public void exampleMethod() {
+        // Code goes here ...
+    }
+}
 
 **Current Functionalities:**
 
@@ -116,6 +128,8 @@ public class ExampleController {
 * The `@RequestParam(name = "value")` annotation is used to annotate parameters to be mapped to a form attribute.
 * If the parameter is an object, the form attribute value should match the pattern `objectName.attributeName` where objectName is the value of the `@RequestParam` annotation or the declared name of the parameter if no annotation is provided.
 * The `Session` data type allows the developer the use an abstraction of the `HttpSession`.
+* The `@Rest` annotation is used to annotate REST methods.
+* The `@GET`, `@POST` annotations define the access of the methods.
 
 **Future Work:**
 

--- a/packaging/packaging.bat
+++ b/packaging/packaging.bat
@@ -1,6 +1,6 @@
 @echo off
 
-set test_dir="C:\Users\Hasina\Desktop\School\Mr Naina\Projects\Winter Framework\test-project\lib"
+set test_dir="C:\Users\Hasina\Desktop\School\Mr Naina\Projects\winter-framework\test-project\lib"
 
 rem Define the directory containing the class files
 set bin_dir="../bin"

--- a/src/winter/annotations/Controller.java
+++ b/src/winter/annotations/Controller.java
@@ -8,5 +8,4 @@ import java.lang.annotation.ElementType;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Controller {
-    String name() default "";
 }

--- a/src/winter/annotations/GET.java
+++ b/src/winter/annotations/GET.java
@@ -1,0 +1,12 @@
+package winter.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GET {
+    String value() default "";
+}

--- a/src/winter/annotations/GET.java
+++ b/src/winter/annotations/GET.java
@@ -8,5 +8,4 @@ import java.lang.annotation.ElementType;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface GET {
-    String value() default "";
 }

--- a/src/winter/annotations/POST.java
+++ b/src/winter/annotations/POST.java
@@ -1,0 +1,12 @@
+package winter.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface POST {
+    String value() default "";
+}

--- a/src/winter/annotations/POST.java
+++ b/src/winter/annotations/POST.java
@@ -8,5 +8,4 @@ import java.lang.annotation.ElementType;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface POST {
-    String value() default "";
 }

--- a/src/winter/annotations/Rest.java
+++ b/src/winter/annotations/Rest.java
@@ -8,5 +8,4 @@ import java.lang.annotation.ElementType;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Rest {
-    String value() default "";
 }

--- a/src/winter/annotations/UriMapping.java
+++ b/src/winter/annotations/UriMapping.java
@@ -7,6 +7,6 @@ import java.lang.annotation.ElementType;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface GetMapping {
+public @interface UriMapping {
     String value() default "";
 }

--- a/src/winter/annotations/UrlMapping.java
+++ b/src/winter/annotations/UrlMapping.java
@@ -7,6 +7,6 @@ import java.lang.annotation.ElementType;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface UriMapping {
+public @interface UrlMapping {
     String value() default "";
 }

--- a/src/winter/controllers/FrontController.java
+++ b/src/winter/controllers/FrontController.java
@@ -135,6 +135,11 @@ public class FrontController extends HttpServlet {
         }
 
         MappingMethod mappingMethod = mapping.getMethod(requestVerb);
+
+        if (mappingMethod == null) {
+            throw new InvalidRequestVerbException("Access denied for the specified URL");
+        }
+
         Object result = ReflectionUtil.invokeControllerMethod(mapping, req);
         Gson gson = new Gson();
 

--- a/src/winter/controllers/FrontController.java
+++ b/src/winter/controllers/FrontController.java
@@ -107,12 +107,12 @@ public class FrontController extends HttpServlet {
                 handleRequest(req, resp, targetURL, out, requestVerb);
             } catch (MappingNotFoundException | InvalidReturnTypeException e) {
                 ExceptionHandler.handleException(e, Level.WARNING, resp);
+            } catch (IllegalAccessException | AnnotationNotFoundException e) {
+                ExceptionHandler.handleException(e, Level.SEVERE, resp);
             } catch (ReflectiveOperationException e) {
                 ExceptionHandler.handleException(
                         new ReflectiveOperationException("An error occurred while processing the requested URL", e),
                         Level.SEVERE, resp);
-            } catch (AnnotationNotFoundException e) {
-                ExceptionHandler.handleException(e, Level.SEVERE, resp);
             } catch (Exception e) {
                 ExceptionHandler.handleException(new Exception("An unexpected error occurred", e), Level.SEVERE, resp);
             }
@@ -121,7 +121,8 @@ public class FrontController extends HttpServlet {
 
     private void handleRequest(HttpServletRequest req, HttpServletResponse resp, String targetURL, PrintWriter out,
             RequestVerb requestVerb)
-            throws MappingNotFoundException, AnnotationNotFoundException, ReflectiveOperationException,
+            throws MappingNotFoundException, AnnotationNotFoundException,
+            ReflectiveOperationException,
             InvalidReturnTypeException, ServletException,
             IOException {
         Mapping mapping = urlMappings.get(targetURL);
@@ -130,7 +131,9 @@ public class FrontController extends HttpServlet {
             throw new MappingNotFoundException("Resource not found for URL: " + targetURL);
         }
 
-        // TODO: Throws IllegalAccessException if RequestVerb doesn't match
+        if (requestVerb != mapping.getRequestVerb()) {
+            throw new IllegalAccessException("Illegal access to the designated resource.");
+        }
 
         Object result = ReflectionUtil.invokeControllerMethod(mapping, req);
         Gson gson = new Gson();

--- a/src/winter/controllers/FrontController.java
+++ b/src/winter/controllers/FrontController.java
@@ -140,7 +140,7 @@ public class FrontController extends HttpServlet {
             throw new InvalidRequestVerbException("Access denied for the specified URL");
         }
 
-        Object result = ReflectionUtil.invokeControllerMethod(mapping, req);
+        Object result = ReflectionUtil.invokeControllerMethod(mapping.getClassName(), mappingMethod, req);
         Gson gson = new Gson();
 
         if (mappingMethod.isRest()) {

--- a/src/winter/data/Mapping.java
+++ b/src/winter/data/Mapping.java
@@ -1,5 +1,6 @@
 package winter.data;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import winter.exceptions.DuplicateMappingException;
@@ -11,6 +12,7 @@ public class Mapping {
 
     /* ------------------------------ Constructors ------------------------------ */
     public Mapping() {
+        this.setMappingMethods(new HashSet<>());
     }
 
     public Mapping(String className, Set<MappingMethod> mappingMethods) {

--- a/src/winter/data/Mapping.java
+++ b/src/winter/data/Mapping.java
@@ -2,6 +2,8 @@ package winter.data;
 
 import java.util.Set;
 
+import winter.exceptions.InvalidRequestVerbException;
+
 public class Mapping {
 
     private String className;
@@ -34,5 +36,14 @@ public class Mapping {
     }
 
     /* --------------------------------- Methods -------------------------------- */
+    public MappingMethod getMethod(RequestVerb verb) throws InvalidRequestVerbException {
+        for (MappingMethod mappingMethod : this.getMappingMethods()) {
+            if (mappingMethod.getVerb() == verb) {
+                return mappingMethod;
+            }
+        }
+
+        throw new InvalidRequestVerbException("Access denied for the specified URL");
+    }
 
 }

--- a/src/winter/data/Mapping.java
+++ b/src/winter/data/Mapping.java
@@ -1,61 +1,38 @@
 package winter.data;
 
+import java.util.Set;
+
 public class Mapping {
-    private String sClass;
-    private String sMethod;
-    private Class<?>[] methodParamTypes = new Class<?>[0];
-    private boolean isRest = false;
-    private RequestVerb requestVerb = RequestVerb.GET;
 
-    // Constructors
-    public Mapping(String sClass, String sMethod) {
-        this.setClassName(sClass);
-        this.setMethodName(sMethod);
+    private String className;
+    private Set<MappingMethod> mappingMethods;
+
+    /* ------------------------------ Constructors ------------------------------ */
+    public Mapping() {
     }
 
-    public Mapping(String sClass, String sMethod, Class<?>[] methodParamTypes) {
-        this(sClass, sMethod);
-        this.setMethodParamTypes(methodParamTypes);
+    public Mapping(String className, Set<MappingMethod> mappingMethods) {
+        this.setClassName(className);
+        this.setMappingMethods(mappingMethods);
     }
 
-    // Getters & Setters
+    /* --------------------------- Getters and setters -------------------------- */
     public String getClassName() {
-        return this.sClass;
+        return className;
     }
 
-    public void setClassName(String sClass) {
-        this.sClass = sClass;
+    public void setClassName(String className) {
+        this.className = className;
     }
 
-    public String getMethodName() {
-        return this.sMethod;
+    public Set<MappingMethod> getMappingMethods() {
+        return mappingMethods;
     }
 
-    public void setMethodName(String sMethod) {
-        this.sMethod = sMethod;
+    public void setMappingMethods(Set<MappingMethod> mappingMethods) {
+        this.mappingMethods = mappingMethods;
     }
 
-    public Class<?>[] getMethodParamTypes() {
-        return this.methodParamTypes;
-    }
+    /* --------------------------------- Methods -------------------------------- */
 
-    public void setMethodParamTypes(Class<?>[] methodParamTypes) {
-        this.methodParamTypes = methodParamTypes;
-    }
-
-    public boolean getIsRest() {
-        return this.isRest;
-    }
-
-    public void setIsRest(boolean isRest) {
-        this.isRest = isRest;
-    }
-
-    public RequestVerb getRequestVerb() {
-        return requestVerb;
-    }
-
-    public void setRequestVerb(RequestVerb requestVerb) {
-        this.requestVerb = requestVerb;
-    }
 }

--- a/src/winter/data/Mapping.java
+++ b/src/winter/data/Mapping.java
@@ -2,6 +2,7 @@ package winter.data;
 
 import java.util.Set;
 
+import winter.exceptions.DuplicateMappingException;
 import winter.exceptions.InvalidRequestVerbException;
 
 public class Mapping {
@@ -44,6 +45,15 @@ public class Mapping {
         }
 
         throw new InvalidRequestVerbException("Access denied for the specified URL");
+    }
+
+    public void addMethod(MappingMethod mappingMethod) throws DuplicateMappingException {
+        if (this.getMappingMethods().contains(mappingMethod)) {
+            throw new DuplicateMappingException(
+                    "Duplicate controller method for the URL '" + mappingMethod.getUrlMapping() + "'");
+        }
+
+        this.getMappingMethods().add(mappingMethod);
     }
 
 }

--- a/src/winter/data/Mapping.java
+++ b/src/winter/data/Mapping.java
@@ -5,6 +5,7 @@ public class Mapping {
     private String sMethod;
     private Class<?>[] methodParamTypes = new Class<?>[0];
     private boolean isRest = false;
+    private RequestVerb requestVerb = RequestVerb.GET;
 
     // Constructors
     public Mapping(String sClass, String sMethod) {
@@ -48,5 +49,13 @@ public class Mapping {
 
     public void setIsRest(boolean isRest) {
         this.isRest = isRest;
+    }
+
+    public RequestVerb getRequestVerb() {
+        return requestVerb;
+    }
+
+    public void setRequestVerb(RequestVerb requestVerb) {
+        this.requestVerb = requestVerb;
     }
 }

--- a/src/winter/data/Mapping.java
+++ b/src/winter/data/Mapping.java
@@ -3,7 +3,6 @@ package winter.data;
 import java.util.Set;
 
 import winter.exceptions.DuplicateMappingException;
-import winter.exceptions.InvalidRequestVerbException;
 
 public class Mapping {
 
@@ -47,14 +46,14 @@ public class Mapping {
         return false;
     }
 
-    public MappingMethod getMethod(RequestVerb verb) throws InvalidRequestVerbException {
+    public MappingMethod getMethod(RequestVerb verb) {
         for (MappingMethod mappingMethod : this.getMappingMethods()) {
             if (mappingMethod.getVerb() == verb) {
                 return mappingMethod;
             }
         }
 
-        throw new InvalidRequestVerbException("Access denied for the specified URL");
+        return null;
     }
 
     public void addMethod(MappingMethod mappingMethod) throws DuplicateMappingException {

--- a/src/winter/data/Mapping.java
+++ b/src/winter/data/Mapping.java
@@ -37,6 +37,16 @@ public class Mapping {
     }
 
     /* --------------------------------- Methods -------------------------------- */
+    public boolean hasVerb(RequestVerb verb) {
+        for (MappingMethod mappingMethod : this.getMappingMethods()) {
+            if (mappingMethod.getVerb() == verb) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public MappingMethod getMethod(RequestVerb verb) throws InvalidRequestVerbException {
         for (MappingMethod mappingMethod : this.getMappingMethods()) {
             if (mappingMethod.getVerb() == verb) {

--- a/src/winter/data/MappingMethod.java
+++ b/src/winter/data/MappingMethod.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.util.Objects;
 
 import winter.annotations.Rest;
+import winter.annotations.UrlMapping;
 
 public class MappingMethod {
 
@@ -39,6 +40,10 @@ public class MappingMethod {
     /* --------------------------------- Methods -------------------------------- */
     public boolean isRest() {
         return this.getMethod().isAnnotationPresent(Rest.class);
+    }
+
+    public String getUrlMapping() {
+        return this.getMethod().getAnnotation(UrlMapping.class).value();
     }
 
     @Override

--- a/src/winter/data/MappingMethod.java
+++ b/src/winter/data/MappingMethod.java
@@ -3,6 +3,7 @@ package winter.data;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
+import winter.annotations.POST;
 import winter.annotations.Rest;
 import winter.annotations.UrlMapping;
 
@@ -13,6 +14,11 @@ public class MappingMethod {
 
     /* ------------------------------ Constructors ------------------------------ */
     public MappingMethod() {
+    }
+
+    public MappingMethod(Method method) {
+        this.setMethod(method);
+        this.setVerb();
     }
 
     public MappingMethod(Method method, RequestVerb verb) {
@@ -35,6 +41,15 @@ public class MappingMethod {
 
     public void setVerb(RequestVerb verb) {
         this.verb = verb;
+    }
+
+    private void setVerb() {
+        if (this.getMethod().isAnnotationPresent(POST.class)) {
+            this.setVerb(RequestVerb.POST);
+            return;
+        }
+
+        this.setVerb(RequestVerb.GET);
     }
 
     /* --------------------------------- Methods -------------------------------- */

--- a/src/winter/data/MappingMethod.java
+++ b/src/winter/data/MappingMethod.java
@@ -3,6 +3,8 @@ package winter.data;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
+import winter.annotations.Rest;
+
 public class MappingMethod {
 
     private Method method;
@@ -35,6 +37,10 @@ public class MappingMethod {
     }
 
     /* --------------------------------- Methods -------------------------------- */
+    public boolean isRest() {
+        return this.getMethod().isAnnotationPresent(Rest.class);
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof MappingMethod)) {

--- a/src/winter/data/MappingMethod.java
+++ b/src/winter/data/MappingMethod.java
@@ -74,7 +74,7 @@ public class MappingMethod {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this);
+        return Objects.hash(this.getMethod(), this.getVerb());
     }
 
 }

--- a/src/winter/data/MappingMethod.java
+++ b/src/winter/data/MappingMethod.java
@@ -1,0 +1,54 @@
+package winter.data;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+public class MappingMethod {
+
+    private Method method;
+    private RequestVerb verb;
+
+    /* ------------------------------ Constructors ------------------------------ */
+    public MappingMethod() {
+    }
+
+    public MappingMethod(Method method, RequestVerb verb) {
+        this.setMethod(method);
+        this.setVerb(verb);
+    }
+
+    /* --------------------------- Getters and setters -------------------------- */
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+    }
+
+    public RequestVerb getVerb() {
+        return verb;
+    }
+
+    public void setVerb(RequestVerb verb) {
+        this.verb = verb;
+    }
+
+    /* --------------------------------- Methods -------------------------------- */
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof MappingMethod)) {
+            return false;
+        }
+
+        MappingMethod toCompare = (MappingMethod) obj;
+        return this.getMethod().getName().equalsIgnoreCase(toCompare.getMethod().getName())
+                && this.getVerb() == toCompare.getVerb();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this);
+    }
+
+}

--- a/src/winter/data/RequestVerb.java
+++ b/src/winter/data/RequestVerb.java
@@ -1,0 +1,8 @@
+package winter.data;
+
+public enum RequestVerb {
+    GET,
+    POST,
+    PUT,
+    DELETE
+}

--- a/src/winter/exceptions/InvalidRequestVerbException.java
+++ b/src/winter/exceptions/InvalidRequestVerbException.java
@@ -1,0 +1,31 @@
+package winter.exceptions;
+
+/**
+ * Custom exception for invalid HTTP request verbs.
+ */
+public class InvalidRequestVerbException extends Exception {
+
+    /**
+     * Constructs a new InvalidRequestVerbException with the specified detail
+     * message.
+     *
+     * @param message The detail message, which provides more information about the
+     *                invalid verb.
+     */
+    public InvalidRequestVerbException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new InvalidRequestVerbException with the specified detail
+     * message and cause.
+     *
+     * @param message The detail message, which provides more information about the
+     *                invalid verb.
+     * @param cause   The cause of the exception, which may be another exception.
+     */
+    public InvalidRequestVerbException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import jakarta.servlet.ServletContext;
 import winter.data.Mapping;
+import winter.data.RequestVerb;
 import winter.exceptions.DuplicateMappingException;
 import winter.exceptions.InvalidPackageNameException;
 import winter.exceptions.PackageProviderNotFoundException;
@@ -79,7 +80,10 @@ public class AnnotationScanner extends Utility {
                 Mapping mapping = new Mapping(clazz.getName(), sMethod, methodParamTypes);
                 mapping.setIsRest(method.isAnnotationPresent(Rest.class));
 
-                // TODO: Change RequestVerb of mapping based on the annotation
+                // Change RequestVerb of mapping based on the annotation
+                if (method.isAnnotationPresent(POST.class)) {
+                    mapping.setRequestVerb(RequestVerb.POST);
+                }
 
                 if (urlMappings.putIfAbsent(sURL, mapping) != null) {
                     throw new DuplicateMappingException("Duplicate mapping found for URL: " + sURL);

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -82,7 +82,7 @@ public class AnnotationScanner extends Utility {
                 mapping.addMethod(mappingMethod);
                 mapping = urlMappings.putIfAbsent(url, mapping);
 
-                if (urlMappings.putIfAbsent(url, mapping) != null) {
+                if (mapping != null) {
                     mapping.addMethod(mappingMethod);
                 }
             }

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -79,6 +79,8 @@ public class AnnotationScanner extends Utility {
                 Mapping mapping = new Mapping(clazz.getName(), sMethod, methodParamTypes);
                 mapping.setIsRest(method.isAnnotationPresent(Rest.class));
 
+                // TODO: Change RequestVerb of mapping based on the annotation
+
                 if (urlMappings.putIfAbsent(sURL, mapping) != null) {
                     throw new DuplicateMappingException("Duplicate mapping found for URL: " + sURL);
                 }

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -72,8 +72,8 @@ public class AnnotationScanner extends Utility {
         Method[] methods = clazz.getMethods();
 
         for (Method method : methods) {
-            if (method.isAnnotationPresent(UriMapping.class)) {
-                String sURL = method.getAnnotation(UriMapping.class).value();
+            if (method.isAnnotationPresent(UrlMapping.class)) {
+                String sURL = method.getAnnotation(UrlMapping.class).value();
                 String sMethod = method.getName();
                 Class<?>[] methodParamTypes = method.getParameterTypes();
 

--- a/src/winter/utils/AnnotationScanner.java
+++ b/src/winter/utils/AnnotationScanner.java
@@ -72,8 +72,8 @@ public class AnnotationScanner extends Utility {
         Method[] methods = clazz.getMethods();
 
         for (Method method : methods) {
-            if (method.isAnnotationPresent(GetMapping.class)) {
-                String sURL = method.getAnnotation(GetMapping.class).value();
+            if (method.isAnnotationPresent(UriMapping.class)) {
+                String sURL = method.getAnnotation(UriMapping.class).value();
                 String sMethod = method.getName();
                 Class<?>[] methodParamTypes = method.getParameterTypes();
 

--- a/src/winter/utils/ReflectionUtil.java
+++ b/src/winter/utils/ReflectionUtil.java
@@ -47,8 +47,8 @@ public class ReflectionUtil extends Utility {
     }
 
     private static void injectSession(Object object, HttpSession httpSession)
-            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException,
-            IllegalArgumentException, SecurityException {
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, IllegalArgumentException,
+            SecurityException {
         Class<?> clazz = object.getClass();
         String attrName = hasSession(clazz);
 

--- a/src/winter/utils/ReflectionUtil.java
+++ b/src/winter/utils/ReflectionUtil.java
@@ -11,19 +11,19 @@ import java.util.List;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import winter.annotations.RequestParam;
-import winter.data.Mapping;
+import winter.data.MappingMethod;
 import winter.data.Session;
 import winter.exceptions.AnnotationNotFoundException;
 
 public class ReflectionUtil extends Utility {
-    public static Object invokeControllerMethod(Mapping mapping, HttpServletRequest req)
+    public static Object invokeControllerMethod(String className, MappingMethod mappingMethod, HttpServletRequest req)
             throws AnnotationNotFoundException, ReflectiveOperationException {
-        String className = mapping.getClassName();
-        String methodName = mapping.getMethodName();
+
+        String methodName = mappingMethod.getMethod().getName();
 
         try {
             Class<?> clazz = Class.forName(className);
-            Method method = clazz.getDeclaredMethod(methodName, mapping.getMethodParamTypes());
+            Method method = mappingMethod.getMethod();
             Object[] args = initializeMethodArguments(method.getParameters(), req);
 
             // Inject session if it's defined


### PR DESCRIPTION
- Add request verb validation to the `@UrlMapping`. By default, it is set to `@GET`.
- Send an `Illegal access error` if the request verb and the method verb don't match.
- Supported verbs for the moment are `@GET` and `@POST`.